### PR TITLE
Update mgos_crontab.c

### DIFF
--- a/src/mgos_crontab.c
+++ b/src/mgos_crontab.c
@@ -613,8 +613,8 @@ static void cron_cb(void *user_data, mgos_cron_id_t cron_id) {
   }
 
   LOG(LL_DEBUG, ("Cron job %ld is firing: \"%.*s\" %.*s", (long) iid,
-                (int) ctx.action.len, ctx.action.p, (int) ctx.payload.len,
-                ctx.payload.p));
+                 (int) ctx.action.len, ctx.action.p, (int) ctx.payload.len,
+                 ctx.payload.p));
   if (!ctx.enable) {
     LOG(LL_WARN, ("Cron job %ld is disabled, but still fired!", (long) iid));
   }

--- a/src/mgos_crontab.c
+++ b/src/mgos_crontab.c
@@ -612,7 +612,7 @@ static void cron_cb(void *user_data, mgos_cron_id_t cron_id) {
     goto clean;
   }
 
-  LOG(LL_INFO, ("Cron job %ld is firing: \"%.*s\" %.*s", (long) iid,
+  LOG(LL_DEBUG, ("Cron job %ld is firing: \"%.*s\" %.*s", (long) iid,
                 (int) ctx.action.len, ctx.action.p, (int) ctx.payload.len,
                 ctx.payload.p));
   if (!ctx.enable) {


### PR DESCRIPTION
Demote info to debug message. This clutters the log quite and makes actual application code hard to debug.