### PR TITLE
Update mgos_crontab.h

### DIFF
--- a/include/mgos_crontab.h
+++ b/include/mgos_crontab.h
@@ -73,6 +73,7 @@
 #define CS_MOS_LIBS_CRONTAB_SRC_CRONTAB_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "common/mg_str.h"
 


### PR DESCRIPTION
#include <stdint.h> required for intptr_t. Compilation fails with 2.20.0 and also current latest for esp8266
